### PR TITLE
Fix windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ You can also run the installation command manually.
 
 - `pylsp.enable`: Enable coc-pylsp extension, default: `true`
 - `pylsp.commandPath`: The custom path to the pylsp (Absolute path), default: `""`
+- `pylsp.pylsp.builtin.pythonPath`: Python 3.x path (Absolute path) to be used for built-in install, default: `""`
 - `pylsp.builtin.extrasArgs`: Setting extras_require for built-in installation, default: `["all"]`
 - `pylsp.configurationSources`: List of configuration sources to use, valid options `["pycodestyle", "pyflakes"]`, default: `["pycodestyle"]`
 - `pylsp.plugins.jedi.extra_paths`: Define extra paths for jedi.Script, default: `[]`
@@ -116,7 +117,7 @@ You can also run the installation command manually.
 - `pylsp.installServer`: Install pylsp (builtin)
   - It will be installed in this path:
     - Mac/Linux: `~/.config/coc/extensions/coc-pylsp-data/pylsp/venv/bin/pylsp`
-    - Windows: `~/AppData/Local/coc/extensions/coc-pylsp-data/pylsp/venv/bin/pylsp`
+    - Windows: `~/AppData/Local/coc/extensions/coc-pylsp-data/pylsp/venv/Scripts/pylsp.exe`
 
 ## Other python-related coc.nvim extensions
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@types/node": "^12.11.7",
     "@types/rimraf": "^3.0.0",
+    "@types/which": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "@typescript-eslint/parser": "^4.8.2",
     "coc.nvim": "^0.0.80",
@@ -43,7 +44,8 @@
     "eslint-plugin-prettier": "^3.1.4",
     "prettier": "^2.2.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.2",
+    "which": "^2.0.2"
   },
   "activationEvents": [
     "onLanguage:python"
@@ -61,7 +63,12 @@
         "pylsp.commandPath": {
           "type": "string",
           "default": "",
-          "description": "(Optional) The custom path to the pylsp (Absolute path)."
+          "description": "The custom path to the pylsp (Absolute path)."
+        },
+        "pylsp.builtin.pythonPath": {
+          "type": "string",
+          "default": "",
+          "description": "Python 3.x path (Absolute path) to be used for built-in install"
         },
         "pylsp.builtin.extrasArgs": {
           "type": "array",

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -30,7 +30,7 @@ export async function pylspInstall(pythonCommand: string, context: ExtensionCont
     const installEtrasArgs = extrasArgs.join(',');
     installCmd =
       `${pythonCommand} -m venv ${pathVenv} && ` +
-      `${pathVenvPython} -m pip install -U pip 'python-lsp-server[${installEtrasArgs}]'==${PYLSP_VERSION}`;
+      `${pathVenvPython} -m pip install -U pip python-lsp-server[${installEtrasArgs}]==${PYLSP_VERSION}`;
   } else {
     installCmd =
       `${pythonCommand} -m venv ${pathVenv} && ` +

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -10,12 +10,16 @@ import { PYLSP_VERSION } from './constant';
 
 const exec = util.promisify(child_process.exec);
 
-export async function pylspInstall(context: ExtensionContext): Promise<void> {
+export async function pylspInstall(pythonCommand: string, context: ExtensionContext): Promise<void> {
   const pathVenv = path.join(context.storagePath, 'pylsp', 'venv');
-  const pathPip = path.join(pathVenv, 'bin', 'pip');
+
+  let pathVenvPython = path.join(context.storagePath, 'pylsp', 'venv', 'bin', 'python');
+  if (process.platform === 'win32') {
+    pathVenvPython = path.join(context.storagePath, 'pylsp', 'venv', 'Scripts', 'python');
+  }
 
   const statusItem = window.createStatusBarItem(0, { progress: true });
-  statusItem.text = `Install pylsp ...`;
+  statusItem.text = `Install pylsp...`;
   statusItem.show();
 
   const extensionConfig = workspace.getConfiguration('pylsp');
@@ -25,18 +29,20 @@ export async function pylspInstall(context: ExtensionContext): Promise<void> {
   if (extrasArgs.length >= 1) {
     const installEtrasArgs = extrasArgs.join(',');
     installCmd =
-      `python3 -m venv ${pathVenv} && ` +
-      `${pathPip} install -U pip 'python-lsp-server[${installEtrasArgs}]'==${PYLSP_VERSION}`;
+      `${pythonCommand} -m venv ${pathVenv} && ` +
+      `${pathVenvPython} -m pip install -U pip 'python-lsp-server[${installEtrasArgs}]'==${PYLSP_VERSION}`;
   } else {
-    installCmd = `python3 -m venv ${pathVenv} && ` + `${pathPip} install -U pip python-lsp-server==${PYLSP_VERSION}`;
+    installCmd =
+      `${pythonCommand} -m venv ${pathVenv} && ` +
+      `${pathVenvPython} install -U pip python-lsp-server==${PYLSP_VERSION}`;
   }
 
   rimraf.sync(pathVenv);
   try {
-    window.showWarningMessage(`Install pylsp ...`);
+    window.showMessage(`Install pylsp...`);
     await exec(installCmd);
     statusItem.hide();
-    window.showWarningMessage(`pylsp: installed!`);
+    window.showMessage(`pylsp: installed!`);
   } catch (error) {
     statusItem.hide();
     window.showErrorMessage(`pylsp: install failed. | ${error}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,6 +95,11 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/which@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-2.0.0.tgz#446d35586611dee657120de8e0457382a658fc25"
+  integrity sha512-JHTNOEpZnACQdsTojWggn+SQ8IucfqEhtz7g8Z0G67WdSj4x3F0X5I2c/CVcl8z/QukGrIHeQ/N49v1au74XFQ==
+
 "@typescript-eslint/eslint-plugin@^4.8.2":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz#3d5f29bb59e61a9dba1513d491b059e536e16dbc"
@@ -295,8 +300,6 @@ color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
-  dependencies:
-    color-name "1.1.3"
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -304,11 +307,6 @@ color-convert@^2.0.1:
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
-
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 color-name@~1.1.4:
   version "1.1.4"
@@ -1088,7 +1086,7 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
- Fix path of venv on windows (Change to Scripts instead of bin.)
- Change the installation procedure to `python -m pip` instead of using pip in venv directly.
- Added python3 and python command detection (since python3 commands may not be present on Windows and other special environments).