### PR TITLE
feat: add tcp connection mode (default is "stdio")

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,34 @@ You can also run the installation command manually.
 :CocComannd pylsp.builtin.install
 ```
 
+## Use tcp mode
+
+To use the tcp mode, set `pylsp.connectionMode` to `'tcp'`. Also, pylsp needs to be started in tcp mode separately.
+
+**coc-settings.json**:
+
+```json
+{
+  "pylsp.connectionMode": "tcp"
+}
+```
+
+**How to start pylsp in tcp mode**:
+
+```sh
+# By default, host is 127.0.0.1 and port 2087 is set
+pylsp --tcp
+# Or specify any host (--host) and port (--port)
+pylsp --tcp --host 127.0.0.1 --port 2087
+```
+
 ## Configuration options
 
 - `pylsp.enable`: Enable coc-pylsp extension, default: `true`
 - `pylsp.commandPath`: Custom path to the pylsp command. `~` and `$HOME`, etc. can also be used. If not set, pylsp detected by the current python environment or extension venv's pylsp used will be used, default: `""`
+- `pylsp.connectionMode`: Controls the communication method to pylsp, valid option `["stdio", "tcp"]`, default: `stdio`
+- `pylsp.tcpHost`: Specifies the host name to connect pylsp. This setting only works with connectionMode is 'tcp', default: `"127.0.0.1"`
+- `pylsp.tcpPort`: Specifies the port to connect pylsp. This setting only works with connectionMode is 'tcp', default: `2087`
 - `pylsp.pylsp.builtin.pythonPath`: Python 3.x path (Absolute path) to be used for built-in install, default: `""`
 - `pylsp.builtin.installExtrasArgs`: Setting extras_require for built-in installation, default: `["all"]`
 - `pylsp.builtin.enableInstallPylspMypy`: Enable/Disable built-in install of `pylsp-mypy`, default: `false`

--- a/package.json
+++ b/package.json
@@ -79,6 +79,32 @@
           "default": "",
           "description": "Custom path to the pylsp command. ~ and $HOME, etc. can also be used. If not set, pylsp detected by the current python environment or extension venv's pylsp used will be used"
         },
+        "pylsp.connectionMode": {
+          "scope": "resource",
+          "type": "string",
+          "default": "stdio",
+          "markdownDescription": "Controls the communication method to pylsp.",
+          "enum": [
+            "stdio",
+            "tcp"
+          ],
+          "enumDescriptions": [
+            "Use stdio to communicate with pylsp.",
+            "Use tcp to connect pylsp. You need to launch pylsp."
+          ]
+        },
+        "pylsp.tcpHost": {
+          "scope": "resource",
+          "type": "string",
+          "default": "127.0.0.1",
+          "description": "Specifies the host name to connect pylsp. This setting only works with connectionMode is 'tcp'."
+        },
+        "pylsp.tcpPort": {
+          "scope": "resource",
+          "type": "number",
+          "default": "2087",
+          "markdownDescription": "Specifies the port to connect pylsp. This setting only works with connectionMode is 'tcp'."
+        },
         "pylsp.builtin.pythonPath": {
           "type": "string",
           "default": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
 } from 'coc.nvim';
 
 import fs from 'fs';
+import net from 'net';
 
 import { pylspInstall } from './installer';
 import { existsPythonImportModule, getBuiltinToolPath, getCurrentPythonPath } from './tool';
@@ -27,6 +28,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   const { subscriptions } = context;
   const pythonCommand = getCurrentPythonPath(extConfig);
+  const connectionMode = extConfig.get<string>('connectionMode', 'stdio');
+  const tcpHost = extConfig.get<string>('tcpHost', '127.0.0.1');
+  const tcpPort = extConfig.get<number>('tcpPort', 2087);
 
   // MEMO: Priority to detect pylsp
   //
@@ -35,39 +39,42 @@ export async function activate(context: ExtensionContext): Promise<void> {
   // 3. builtin pylsp
   let existsPylspModule = false;
   let pylspPath: string | undefined = extConfig.get('commandPath', '');
-  if (pylspPath) {
-    workspace.expand(pylspPath);
-    if (!fs.existsSync(pylspPath)) {
-      pylspPath = undefined;
-    }
-  }
-  if (!pylspPath) {
-    if (pythonCommand) {
-      if (await existsPythonImportModule(pythonCommand.env, 'pylsp')) {
-        pylspPath = 'dummy';
-        existsPylspModule = true;
-      }
 
-      if (!existsPylspModule) {
-        pylspPath = getBuiltinToolPath(context.storagePath, 'pylsp');
+  if (connectionMode === 'stdio') {
+    if (pylspPath) {
+      workspace.expand(pylspPath);
+      if (!fs.existsSync(pylspPath)) {
+        pylspPath = undefined;
       }
     }
-  }
+    if (!pylspPath) {
+      if (pythonCommand) {
+        if (await existsPythonImportModule(pythonCommand.env, 'pylsp')) {
+          pylspPath = 'dummy';
+          existsPylspModule = true;
+        }
 
-  // Install "pylsp" if it does not exist.
-  if (!pylspPath && !existsPylspModule) {
-    if (pythonCommand) {
-      await installWrapper(pythonCommand.real, context);
-    } else {
-      window.showErrorMessage('python3/python command not found');
+        if (!existsPylspModule) {
+          pylspPath = getBuiltinToolPath(context.storagePath, 'pylsp');
+        }
+      }
     }
-    pylspPath = getBuiltinToolPath(context.storagePath, 'pylsp');
-  }
 
-  // If "pylsp" does not exist completely, terminate the process.
-  if (!pylspPath) {
-    window.showErrorMessage('Exit because "pylsp" does not exist.');
-    return;
+    // Install "pylsp" if it does not exist.
+    if (!pylspPath && !existsPylspModule) {
+      if (pythonCommand) {
+        await installWrapper(pythonCommand.real, context);
+      } else {
+        window.showErrorMessage('python3/python command not found');
+      }
+      pylspPath = getBuiltinToolPath(context.storagePath, 'pylsp');
+    }
+
+    // If "pylsp" does not exist completely, terminate the process.
+    if (!pylspPath) {
+      window.showErrorMessage('Exit because "pylsp" does not exist.');
+      return;
+    }
   }
 
   // old command. It is kept for compatibility,
@@ -96,10 +103,13 @@ export async function activate(context: ExtensionContext): Promise<void> {
     })
   );
 
-  const serverOptions: ServerOptions = {
-    command: existsPylspModule ? 'pylsp' : pylspPath,
-    args: ['-vv'],
-  };
+  let serverOptions: ServerOptions;
+  if (connectionMode === 'tcp') {
+    serverOptions = useLanguageServerOverTCP(tcpHost, tcpPort);
+  } else {
+    const lsCommand = existsPylspModule ? 'pylsp' : pylspPath;
+    serverOptions = useLanguageServerOverStdio(lsCommand);
+  }
 
   const clientOptions: LanguageClientOptions = {
     documentSelector: ['python'],
@@ -114,6 +124,28 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const client = new LanguageClient('pylsp', 'Python lsp server', serverOptions, clientOptions);
 
   subscriptions.push(services.registLanguageClient(client));
+}
+
+function useLanguageServerOverTCP(host: string, port: number): ServerOptions {
+  return () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    return new Promise((resolve, reject) => {
+      const clientSocket = new net.Socket();
+      clientSocket.connect(port, host, () => {
+        resolve({
+          reader: clientSocket,
+          writer: clientSocket,
+        });
+      });
+    });
+  };
+}
+
+function useLanguageServerOverStdio(lsCommand: string): ServerOptions {
+  return {
+    command: lsCommand,
+    args: ['-vv'],
+  };
 }
 
 async function installWrapper(pythonCommand: string, context: ExtensionContext) {


### PR DESCRIPTION
## Description

To use the tcp mode, set `pylsp.connectionMode` to `'tcp'`. Also, pylsp needs to be started in tcp mode separately.

### Example

**coc-settings.json**:

```
{
  "pylsp.connectionMode": "tcp"
}
```


**How to start pylsp in tcp mode**:

```sh
# By default, host is 127.0.0.1 and port 2087 is set
pylsp --tcp
# Or specify any host (--host) and port (--port)
pylsp --tcp --host 127.0.0.1 --port 2087
```

## Add configration options

- `pylsp.connectionMode`: Controls the communication method to pylsp, valid option `["stdio", "tcp"]`, default: `stdio`
- `pylsp.tcpHost`: Specifies the host name to connect pylsp. This setting only works with connectionMode is 'tcp', default: `"127.0.0.1"`
- `pylsp.tcpPort`: Specifies the port to connect pylsp. This setting only works with connectionMode is 'tcp', default: `2087`