### PR TITLE
feat(installer): version specification for third-party tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ To "enable" it, change each setting in `coc-settings.json`.
 }
 ```
 
+It is also possible to specify the version of the third party tool to be installed
+
+```jsonc
+{
+  // snip...
+  "pylsp.builtin.pylspMypyVersion": "0.5.2",
+  "pylsp.builtin.pylsIsortVersion": "0.2.2",
+  "pylsp.builtin.pythonLspBlackVersion": "1.0.1",
+  // snip...
+}
+```
+
 **python-lsp-black tips**:
 
 If you have `yapf` or `autopep8` installed, you may experience unexpected results.
@@ -135,6 +147,9 @@ pylsp --tcp --host 127.0.0.1 --port 2087
 - `pylsp.builtin.enableInstallPylspMypy`: Enable/Disable built-in install of `pylsp-mypy`, default: `false`
 - `pylsp.builtin.enableInstallPylsIsort`: Enable/Disable built-in install of `pyls-isort`, default: `false`
 - `pylsp.builtin.enableInstallPythonLspBlack`: Enable/Disable built-in install of `python-lsp-black`, default: `false`
+- `pylsp.builtin.pylspMypyVersion`: Version of pylsp-mypy for built-in install, e.g. "0.5.2", default: `""`
+- `pylsp.builtin.pylsIsortVersion`: Version of pyls-isort for built-in install, e.g. "0.2.2", default: `""`
+- `pylsp.builtin.pythonLspBlackVersion`: Version of python-lsp-black for built-in install, e.g. "1.0.1" default: `""`
 - `pylsp.trace.server`: Traces the communication between coc.nvim and the Python LSP Server, default: `"off"`
 
 For other settings, Check the "configuration" section of [package.json](/package.json).

--- a/package.json
+++ b/package.json
@@ -132,6 +132,21 @@
           "default": false,
           "description": "Enable/Disable built-in install of python-lsp-black"
         },
+        "pylsp.builtin.pylspMypyVersion": {
+          "type": "string",
+          "default": "",
+          "description": "Version of pylsp-mypy for built-in install"
+        },
+        "pylsp.builtin.pylsIsortVersion": {
+          "type": "string",
+          "default": "",
+          "description": "Version of pyls-isort for built-in install"
+        },
+        "pylsp.builtin.pythonLspBlackVersion": {
+          "type": "string",
+          "default": "",
+          "description": "Version of python-lsp-black for built-in install"
+        },
         "pylsp.configurationSources": {
           "type": "array",
           "default": [

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -27,6 +27,9 @@ export async function pylspInstall(pythonCommand: string, context: ExtensionCont
   const enableInstallPylspMypy = extConfig.get<boolean>('builtin.enableInstallPylspMypy', false);
   const enableInstallPylsIsort = extConfig.get<boolean>('builtin.enableInstallPylsIsort', false);
   const enableInstallPythonLspBlack = extConfig.get<boolean>('builtin.enableInstallPythonLspBlack', false);
+  const pylspMypyVersion = extConfig.get<string>('builtin.pylspMypyVersion', '');
+  const pylsIsortVersion = extConfig.get<string>('builtin.pylsIsortVersion', '');
+  const pythonLspBlackVersion = extConfig.get<string>('builtin.pythonLspBlackVersion', '');
 
   let installCmd: string;
   if (extrasArgs.length >= 1) {
@@ -41,13 +44,16 @@ export async function pylspInstall(pythonCommand: string, context: ExtensionCont
   }
 
   if (enableInstallPylspMypy) {
-    installCmd = installCmd.concat(' ', 'pylsp-mypy');
+    const installPylspMypyStr = installToolVersionStr('pylsp-mypy', pylspMypyVersion);
+    installCmd = installCmd.concat(' ', installPylspMypyStr);
   }
   if (enableInstallPylsIsort) {
-    installCmd = installCmd.concat(' ', 'pyls-isort');
+    const installPylsIsortStr = installToolVersionStr('pyls-isort', pylsIsortVersion);
+    installCmd = installCmd.concat(' ', installPylsIsortStr);
   }
   if (enableInstallPythonLspBlack) {
-    installCmd = installCmd.concat(' ', 'python-lsp-black');
+    const installPythonLspBlackStr = installToolVersionStr('python-lsp-black', pythonLspBlackVersion);
+    installCmd = installCmd.concat(' ', installPythonLspBlackStr);
   }
 
   rimraf.sync(pathVenv);
@@ -61,4 +67,16 @@ export async function pylspInstall(pythonCommand: string, context: ExtensionCont
     window.showErrorMessage(`pylsp and related tools: install failed. | ${error}`);
     throw new Error();
   }
+}
+
+function installToolVersionStr(name: string, version?: string): string {
+  let installStr: string;
+
+  if (version) {
+    installStr = `${name}==${version}`;
+  } else {
+    installStr = `${name}`;
+  }
+
+  return installStr;
 }


### PR DESCRIPTION
Description
-------------------------------------------------------

I found a problem in "v0.5.4" of `pylsp-mypy` that caused the entire pylsp lint to crash in certain cases.

It seems to work fine with `pylsp-mypy` "v0.5.2".

To avoid such problems temporarily, we added the ability to install third party tools by specifying their versions.

Add configuration options
-------------------------------------------------------

- `pylsp.builtin.pylspMypyVersion`: Version of pylsp-mypy for built-in install, e.g. "0.5.2", default: `""`
- `pylsp.builtin.pylsIsortVersion`: Version of pyls-isort for built-in install, e.g. "0.2.2", default: `""`
- `pylsp.builtin.pythonLspBlackVersion`: Version of python-lsp-black for built-in install, e.g. "1.0.1" default: `""`