### PR TITLE
feat: support python-lsp-ruff built-in installer and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ coc-pylsp detects and starts pylsp.
 By default, it is installed with `pip install python-lsp-server[all]`. (extras_require).
 
 <!-- markdownlint-disable-next-line -->
-If you want to change "extras_require", please change the `pylsp.builtin.installExtrasArgs` setting
+gf you want to change "extras_require", please change the `pylsp.builtin.installExtrasArgs` setting
 
 **example**:
 
@@ -55,6 +55,7 @@ It also supports the installation of "3rd Party Plugins".
   - [pyls-isort](https://github.com/paradoxxxzero/pyls-isort)
   - [python-lsp-black](https://github.com/python-lsp/python-lsp-black)
   - [pylsp-rope](https://github.com/python-rope/pylsp-rope)
+  - [python-lsp-ruff](https://github.com/python-lsp/python-lsp-ruff)
 
 By default, the installation of 3rd Party Plugins is "disabled".
 
@@ -67,6 +68,7 @@ To "enable" it, change each setting in `coc-settings.json`.
   "pylsp.builtin.enableInstallPylsIsort": true,
   "pylsp.builtin.enableInstallPythonLspBlack": true,
   "pylsp.builtin.enableInstallPylspRope": true,
+  "pylsp.builtin.enableInstallPythonLspRuff": true,
   // snip...
 }
 ```
@@ -80,6 +82,7 @@ It is also possible to specify the version of the third party tool to be install
   "pylsp.builtin.pylsIsortVersion": "0.2.2",
   "pylsp.builtin.pythonLspBlackVersion": "1.0.1",
   "pylsp.builtin.pylspRopeVersion": "0.1.10",
+  "pylsp.builtin.pythonLspRuffVersion": "1.0.5",
   // snip...
 }
 ```
@@ -152,10 +155,12 @@ pylsp --tcp --host 127.0.0.1 --port 2087
 - `pylsp.builtin.enableInstallPylsIsort`: Enable/Disable built-in install of `pyls-isort`, default: `false`
 - `pylsp.builtin.enableInstallPythonLspBlack`: Enable/Disable built-in install of `python-lsp-black`, default: `false`
 - `pylsp.builtin.enableInstallPylspRope`: Enable/Disable built-in install of `pylsp-rope`, default: `false`
+- `pylsp.builtin.enableInstallPythonLspRuff`: Enable/Disable built-in install of pylsp-lsp-ruff, default: `true`
 - `pylsp.builtin.pylspMypyVersion`: Version of pylsp-mypy for built-in install, e.g. "0.5.2", default: `""`
 - `pylsp.builtin.pylsIsortVersion`: Version of pyls-isort for built-in install, e.g. "0.2.2", default: `""`
 - `pylsp.builtin.pythonLspBlackVersion`: Version of python-lsp-black for built-in install, e.g. "1.0.1" default: `""`
 - `pylsp.builtin.pylspRopeVersion`: Version of pylsp-rope for built-in install, default: `""`
+- `pylsp.builtin.pythonLspRuffVersion`: Version of python-lsp-ruff for built-in install, default: `""`
 
 For other settings, Check the "configuration" section of [package.json](/package.json).
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ coc-pylsp detects and starts pylsp.
 By default, it is installed with `pip install python-lsp-server[all]`. (extras_require).
 
 <!-- markdownlint-disable-next-line -->
-gf you want to change "extras_require", please change the `pylsp.builtin.installExtrasArgs` setting
+If you want to change "extras_require", please change the `pylsp.builtin.installExtrasArgs` setting
 
 **example**:
 

--- a/package.json
+++ b/package.json
@@ -147,6 +147,11 @@
           "default": false,
           "description": "Enable/Disable built-in install of pylsp-rope"
         },
+        "pylsp.builtin.enableInstallPythonLspRuff": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable/Disable built-in install of pylsp-lsp-ruff"
+        },
         "pylsp.builtin.pylspMypyVersion": {
           "type": "string",
           "default": "",
@@ -166,6 +171,11 @@
           "type": "string",
           "default": "",
           "description": "Version of pylsp-rope for built-in install"
+        },
+        "pylsp.builtin.pythonLspRuffVersion": {
+          "type": "string",
+          "default": "",
+          "description": "Version of python-lsp-ruff for built-in install"
         },
         "pylsp.configurationSources": {
           "type": "array",
@@ -643,6 +653,67 @@
           },
           "uniqueItems": true,
           "description": "The name of the folder in which rope stores project configurations and data.  Pass `null` for not using such a folder at all."
+        },
+        "pylsp.plugins.ruff.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "boolean to enable/disable the plugin."
+        },
+        "pylsp.plugins.ruff.config": {
+          "type": [
+            "string",
+            null
+          ],
+          "default": null,
+          "description": "Path to optional pyproject.toml file."
+        },
+        "pylsp.plugins.ruff.exclude": {
+          "type": [
+            "array",
+            null
+          ],
+          "default": null,
+          "description": "Exclude files from being checked by ruff."
+        },
+        "pylsp.plugins.ruff.executable": {
+          "type": [
+            "string",
+            null
+          ],
+          "default": "ruff",
+          "description": " Path to the ruff executable. Assumed to be in PATH by default."
+        },
+        "pylsp.plugins.ruff.ignore": {
+          "type": [
+            "array",
+            null
+          ],
+          "default": null,
+          "description": "Error codes to ignore."
+        },
+        "pylsp.plugins.ruff.lineLength": {
+          "type": [
+            "number",
+            null
+          ],
+          "default": null,
+          "description": "Set the line-length for length checks."
+        },
+        "pylsp.plugins.ruff.perFileIgnore": {
+          "type": [
+            "object",
+            null
+          ],
+          "default": null,
+          "description": "File-specific error codes to be ignored."
+        },
+        "pylsp.plugins.ruff.select": {
+          "type": [
+            "array",
+            null
+          ],
+          "default": null,
+          "description": "List of error codes to enable."
         }
       }
     },

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -29,11 +29,13 @@ export async function pylspInstall(pythonCommand: string, context: ExtensionCont
   const enableInstallPylsIsort = extConfig.get<boolean>('builtin.enableInstallPylsIsort', false);
   const enableInstallPythonLspBlack = extConfig.get<boolean>('builtin.enableInstallPythonLspBlack', false);
   const enableInstallPylspRope = extConfig.get<boolean>('builtin.enableInstallPylspRope', false);
+  const enableInstallPythonLspRuff = extConfig.get<boolean>('builtin.enableInstallPythonLspRuff', false);
 
   const pylspMypyVersion = extConfig.get<string>('builtin.pylspMypyVersion', '');
   const pylsIsortVersion = extConfig.get<string>('builtin.pylsIsortVersion', '');
   const pythonLspBlackVersion = extConfig.get<string>('builtin.pythonLspBlackVersion', '');
   const pylspRopeVersion = extConfig.get<string>('builtin.pylspRopeVersion', '');
+  const pythonLspRuffVersion = extConfig.get<string>('builtin.pythonLspRuffVersion', '');
 
   let installCmd: string;
   if (extrasArgs.length >= 1) {
@@ -62,6 +64,10 @@ export async function pylspInstall(pythonCommand: string, context: ExtensionCont
   if (enableInstallPylspRope) {
     const installPylspRopeStr = installToolVersionStr('pylsp-rope', pylspRopeVersion);
     installCmd = installCmd.concat(' ', installPylspRopeStr);
+  }
+  if (enableInstallPythonLspRuff) {
+    const installPythonLspRuff = installToolVersionStr('python-lsp-ruff', pythonLspRuffVersion);
+    installCmd = installCmd.concat(' ', installPythonLspRuff);
   }
 
   rimraf.sync(pathVenv);


### PR DESCRIPTION
There is a 3rd Party Plugins for pylsp called python-lsp-ruff. We had identified several glitches.

- <https://github.com/python-lsp/python-lsp-ruff>

I have recently added integration in coc-pylsp as well, as it seems that all the problems I am concerned about have been resolved.

- <https://github.com/python-lsp/python-lsp-ruff/issues/11>
- <https://github.com/python-lsp/python-lsp-ruff/issues/10>