### PR TITLE
Fix #24 Unable to find ruff executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ coc-pylsp detects and starts pylsp.
 1. current python3/python environment (e.g. pylsp in venv)
 1. builtin pylsp (Installation commands are also provided)
 
-## Bult-in install (pylsp and 3rd party plugins)
+## Built-in install (pylsp and 3rd party plugins)
 
 `coc-pylsp` allows you to create an extension-only "venv" and install "pylsp (python-lsp-server)" and "related tools" (e.g. pylsp-mypy).
 
@@ -97,6 +97,21 @@ You can also run the installation command manually.
 ```vim
 :CocCommand pylsp.builtin.install
 ```
+
+### python-lsp-ruff
+
+If you enable `python-lsp-ruff` then you will probably want to disable the built-in `pycodestyle`,
+`pyflakes`, `mccabe` and `pyls_isort` plugins, for example:
+```
+{
+  "pylsp.plugins.pycodestyle.enabled": false,
+  "pylsp.plugins.pyflakes.enabled": false
+  "pylsp.plugins.mccabe.enabled": false,
+  "pylsp.plugins.pyls_isort.enabled": false,
+}
+```
+Although `python-lsp-ruff` tries to disable these automatically, they must be explicitly disabled
+when using `coc-pylsp`.
 
 ## Use tcp mode
 

--- a/package.json
+++ b/package.json
@@ -816,6 +816,11 @@
           "default": false,
           "description": "Boolean that enables/disables fixes that are marked \"unsafe\" by `ruff`."
         },
+        "pylsp.plugins.ruff.preview": {
+          "type": "boolean",
+          "default": false,
+          "description": "Boolean that enables/disables rules & fixes that are marked \"preview\" by `ruff`."
+        },
         "pylsp.plugins.ruff.severities": {
           "type": [
             "object",
@@ -823,6 +828,14 @@
           ],
           "default": null,
           "description": "Dictionary of custom severity levels for specific codes."
+        },
+        "pylsp.plugins.ruff.targetVersion": {
+          "type": [
+            "string",
+            null
+          ],
+          "default": null,
+          "description": "The minimum Python version to target."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -259,6 +259,14 @@
           },
           "description": "List of errors and warnings to ignore (or skip)."
         },
+        "pylsp.plugins.flake8.maxComplexity": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "default": null,
+          "description": "Maximum allowed complexity threshold."
+        },
         "pylsp.plugins.flake8.maxLineLength": {
           "type": [
             "integer",
@@ -505,11 +513,6 @@
           "default": null,
           "description": "Hang closing bracket instead of matching indentation of opening bracket's line."
         },
-        "pylsp.plugins.flake8.maxComplexity": {
-          "type": "integer",
-          "default": null,
-          "description": "Maximum allowed complexity threshold."
-        },
         "pylsp.plugins.pycodestyle.maxLineLength": {
           "type": [
             "integer",
@@ -624,7 +627,7 @@
         "pylsp.plugins.rope_autoimport.enabled": {
           "type": "boolean",
           "default": false,
-          "description": "Enable or disable autoimport."
+          "description": "Enable or disable autoimport. If false, neither completions nor code actions are enabled. If true, the respective features can be enabled or disabled individually."
         },
         "pylsp.plugins.rope_autoimport.completions.enabled": {
           "type": "boolean",
@@ -674,27 +677,27 @@
             "type": "string"
           },
           "uniqueItems": true,
-          "description": "The name of the folder in which rope stores project configurations and data.  Pass `null` for not using such a folder at all."
+          "description": "The name of the folder in which rope stores project configurations and data. Pass `null` for not using such a folder at all."
         },
         "pylsp.plugins.black.enabled": {
           "type": "boolean",
           "default": true,
-          "description": "boolean to enable/disable the plugin."
+          "description": "Boolean to enable/disable the plugin."
         },
         "pylsp.plugins.black.cache_config": {
           "type": "boolean",
           "default": false,
-          "description": " a boolean to enable black configuration caching."
+          "description": "A boolean to enable black configuration caching."
         },
         "pylsp.plugins.black.line_length": {
           "type": "number",
           "default": 88,
-          "description": "an integer that maps to black's max-line-length setting. Defaults to 88 (same as black's default). This can also be set through black's configuration files, which should be preferred for multi-user projects."
+          "description": "An integer that maps to black's max-line-length setting. Defaults to 88 (same as black's default). This can also be set through black's configuration files, which should be preferred for multi-user projects."
         },
         "pylsp.plugins.black.preview": {
           "type": "boolean",
           "default": false,
-          "description": " a boolean to enable black configuration caching."
+          "description": "A boolean to enable or disable black's --preview setting."
         },
         "pylsp.plugins.black.skip_string_normalization": {
           "type": "boolean",
@@ -709,7 +712,7 @@
         "pylsp.plugins.ruff.enabled": {
           "type": "boolean",
           "default": true,
-          "description": "boolean to enable/disable the plugin."
+          "description": "Boolean to enable/disable the plugin."
         },
         "pylsp.plugins.ruff.config": {
           "type": [
@@ -717,7 +720,7 @@
             null
           ],
           "default": null,
-          "description": "Path to optional pyproject.toml file."
+          "description": "Path to optional `pyproject.toml` file."
         },
         "pylsp.plugins.ruff.exclude": {
           "type": [
@@ -725,7 +728,10 @@
             null
           ],
           "default": null,
-          "description": "Exclude files from being checked by ruff."
+          "items": {
+            "type": "string"
+          },
+          "description": "Exclude files from being checked by `ruff`."
         },
         "pylsp.plugins.ruff.executable": {
           "type": [
@@ -741,6 +747,9 @@
             null
           ],
           "default": null,
+          "items": {
+            "type": "string"
+          },
           "description": "Error codes to ignore."
         },
         "pylsp.plugins.ruff.extendIgnore": {
@@ -749,11 +758,14 @@
             null
           ],
           "default": null,
+          "items": {
+            "type": "string"
+          },
           "description": "Same as ignore, but append to existing ignores."
         },
         "pylsp.plugins.ruff.lineLength": {
           "type": [
-            "number",
+            "integer",
             null
           ],
           "default": null,
@@ -773,6 +785,9 @@
             null
           ],
           "default": null,
+          "items": {
+            "type": "string"
+          },
           "description": "List of error codes to enable."
         },
         "pylsp.plugins.ruff.extendSelect": {
@@ -781,6 +796,9 @@
             null
           ],
           "default": null,
+          "items": {
+            "type": "string"
+          },
           "description": "Same as select, but append to existing error codes."
         },
         "pylsp.plugins.ruff.format": {
@@ -796,7 +814,7 @@
         "pylsp.plugins.ruff.unsafeFixes": {
           "type": "boolean",
           "default": false,
-          "description": "boolean that enables/disables fixes that are marked \"unsafe\" by `ruff`."
+          "description": "Boolean that enables/disables fixes that are marked \"unsafe\" by `ruff`."
         },
         "pylsp.plugins.ruff.severities": {
           "type": [

--- a/package.json
+++ b/package.json
@@ -701,13 +701,13 @@
         },
         "pylsp.plugins.black.skip_string_normalization": {
           "type": "boolean",
-          "default": true,
-          "description": "a boolean to enable or disable black's --skip-string-normalization setting."
+          "default": false,
+          "description": "A boolean to enable or disable black's --skip-string-normalization setting."
         },
         "pylsp.plugins.black.skip_magic_trailing_comma": {
           "type": "boolean",
-          "default": true,
-          "description": "a boolean to enable or disable black's skip-magic-trailing-comma setting."
+          "default": false,
+          "description": "A boolean to enable or disable black's skip-magic-trailing-comma setting."
         },
         "pylsp.plugins.ruff.enabled": {
           "type": "boolean",
@@ -806,10 +806,11 @@
             "array",
             null
           ],
-          "default": [
-            "I"
-          ],
-          "description": "List of error codes to fix during formatting."
+          "default": null,
+          "items": {
+            "type": "string"
+          },
+          "description": "List of error codes to fix during formatting. Empty by default, use `[\"I\"]` here to get import sorting as part of formatting."
         },
         "pylsp.plugins.ruff.unsafeFixes": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -732,8 +732,8 @@
             "string",
             null
           ],
-          "default": "ruff",
-          "description": " Path to the ruff executable. Assumed to be in PATH by default."
+          "default": null,
+          "description": "Path to the ruff executable. Uses `os.executable -m \"ruff\"` by default."
         },
         "pylsp.plugins.ruff.ignore": {
           "type": [


### PR DESCRIPTION
This PR changes the default value for the `pylsp.plugins.ruff.executable` config setting to `null` (from `ruff`) in order to match the default for `python-lsp-ruff`. This fixes #24 and restores the expected default behaviour of `python-lsp-ruff`, which is to look for `ruff` in the current Python environment. Without this fix the user has to either install `ruff` globally, or ensure their editor is running in a suitably activated virtual environment containing `ruff`.

This PR also:
* updates the README with some additional help text related to `python-lsp-ruff`;
* syncs descriptions, types and missing config options from the upstream LSPs/plugins;
* changes the defaults for some additional config options to match upstream.

The last item in that list (change defaults for some additional config options) will result in a change in behaviour for existing users who haven't overridden these options in their own config. If this is too much of a breaking change then I'm happy to resubmit this PR without that commit, however I do believe that changing the default for `pylsp.plugins.ruff.executable` is important and necessary as the current default will result in a broken ruff plugin for those who don't have a `ruff` binary in their $PATH (and, in fact, completely broken linting due to a bug in `python-lsp-ruff`).